### PR TITLE
Add YAML support for project file

### DIFF
--- a/OKEGui/OKEGui/Gui/WizardWindow.xaml.cs
+++ b/OKEGui/OKEGui/Gui/WizardWindow.xaml.cs
@@ -134,7 +134,7 @@ namespace OKEGui
         private void OpenProjectBtn_Click(object sender, RoutedEventArgs e)
         {
             OpenFileDialog ofd = new OpenFileDialog();
-            ofd.Filter = "OKEGui 项目文件 (*.json;*.yaml)|*.json;*.yaml";
+            ofd.Filter = "OKEGui 项目文件 (*.json;*.yaml;*.yml)|*.json;*.yaml;*.yml";
             var result = ofd.ShowDialog();
             if (result == System.Windows.Forms.DialogResult.Cancel)
             {

--- a/OKEGui/OKEGui/Gui/WizardWindow.xaml.cs
+++ b/OKEGui/OKEGui/Gui/WizardWindow.xaml.cs
@@ -134,7 +134,7 @@ namespace OKEGui
         private void OpenProjectBtn_Click(object sender, RoutedEventArgs e)
         {
             OpenFileDialog ofd = new OpenFileDialog();
-            ofd.Filter = "OKEGui 项目文件 (*.json)|*.json";
+            ofd.Filter = "OKEGui 项目文件 (*.json;*.yaml)|*.json;*.yaml";
             var result = ofd.ShowDialog();
             if (result == System.Windows.Forms.DialogResult.Cancel)
             {

--- a/OKEGui/OKEGui/OKEGui.csproj
+++ b/OKEGui/OKEGui/OKEGui.csproj
@@ -98,6 +98,9 @@
     <Reference Include="Xceed.Wpf.Toolkit, Version=3.5.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
       <HintPath>..\packages\Extended.Wpf.Toolkit.3.5.0\lib\net40\Xceed.Wpf.Toolkit.dll</HintPath>
     </Reference>
+    <Reference Include="YamlDotNet, Version=11.0.0.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e, processorArchitecture=MSIL">
+      <HintPath>..\packages\YamlDotNet.11.1.1\lib\net45\YamlDotNet.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">

--- a/OKEGui/OKEGui/Task/AddTaskService.cs
+++ b/OKEGui/OKEGui/Task/AddTaskService.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Windows;
+using YamlDotNet.Serialization;
 
 namespace OKEGui
 {
@@ -30,7 +31,8 @@ namespace OKEGui
             TaskProfile json;
             try
             {
-                json = JsonConvert.DeserializeObject<TaskProfile>(profileStr);
+                var deserializer = new Deserializer();
+                json = deserializer.Deserialize<TaskProfile>(profileStr);
             }
             catch (Exception e)
             {

--- a/OKEGui/OKEGui/packages.config
+++ b/OKEGui/OKEGui/packages.config
@@ -6,4 +6,5 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NLog" version="4.6.7" targetFramework="net45" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net45" />
+  <package id="YamlDotNet" version="11.1.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR adds YAML support for OKEGui project files, using YamlDotNet as the deserializer.

YAML is a superset of JSON. By adding YAML support, we enjoy its flexible syntax with backward JSON compatibility.

(This PR is not intended to merge immediately. It exists in order to prevent Alkarin’s evil hjson plan.)