### PR TITLE
Add space between a number and its unit

### DIFF
--- a/OKEGui/OKEGui/JobProcessor/Video/CommandlineVideoEncoder.cs
+++ b/OKEGui/OKEGui/JobProcessor/Video/CommandlineVideoEncoder.cs
@@ -144,7 +144,7 @@ namespace OKEGui
             }
             else
             {
-                job.BitRate = bitrate.ToString("0.00") + unit;
+                job.BitRate = bitrate.ToString("0.00") + " " + unit;
             }
 
             // su.NbFramesDone = currentFrameNumber;
@@ -161,7 +161,7 @@ namespace OKEGui
                 i++;
             }
 
-            return Math.Round(size * Math.Pow(10, digit)) / Math.Pow(10, digit) + units[i];
+            return Math.Round(size * Math.Pow(10, digit)) / Math.Pow(10, digit) + " " + units[i];
         }
 
         protected void encodeFinish(ulong reportedFrames)


### PR DESCRIPTION
This fixes AmusementClub/OKEGui#6 reported by @bodayw.