### PR TITLE
Recognize ass/srt subtitles in the source

### DIFF
--- a/OKEGui/OKEGui/JobProcessor/Demuxer/EACDemuxer.cs
+++ b/OKEGui/OKEGui/JobProcessor/Demuxer/EACDemuxer.cs
@@ -71,6 +71,8 @@ namespace OKEGui
             new EacOutputTrackType(TrackCodec.H264_AVC,   "h264/AVC",           "264",     false, TrackType.Video),
             new EacOutputTrackType(TrackCodec.H265_HEVC,  "h265/HEVC",          "265",     false, TrackType.Video),
             new EacOutputTrackType(TrackCodec.PGS,        "Subtitle (PGS)",     "sup",     true,  TrackType.Subtitle),
+            new EacOutputTrackType(TrackCodec.ASS,        "Subtitle (ASS)",     "ass",     true,  TrackType.Subtitle),
+            new EacOutputTrackType(TrackCodec.SRT,        "Subtitle (SRT)",     "srt",     true,  TrackType.Subtitle),
             new EacOutputTrackType(TrackCodec.Chapter,    "Chapters",           "txt",     false, TrackType.Chapter),
             new EacOutputTrackType(TrackCodec.VobSub,     "Subtitle (VobSub)",  "sub",     false, TrackType.Subtitle) //vobsub is not supported by eac3to
         };

--- a/OKEGui/OKEGui/JobProcessor/Demuxer/TrackInfo.cs
+++ b/OKEGui/OKEGui/JobProcessor/Demuxer/TrackInfo.cs
@@ -21,7 +21,9 @@ namespace OKEGui
             DTS,
             PGS,
             Chapter,
-            VobSub
+            VobSub,
+            ASS,
+            SRT
         }
 
         public class TrackInfo


### PR DESCRIPTION
Of course, this change only recognizes these tracks and the only
thing we can do for those tracks is to skip them.

This change makes it possible to process mkv files with text subtitle
tracks.