### PR TITLE
Introduce OKE:PROJECTDIR tag to access files under the project directory

### DIFF
--- a/OKEGui/OKEGui/Gui/WizardWindow.xaml.cs
+++ b/OKEGui/OKEGui/Gui/WizardWindow.xaml.cs
@@ -177,6 +177,13 @@ namespace OKEGui
         // 为所有输入文件生成vs脚本，并添加任务至TaskManager。
         private void WizardFinish(object sender, RoutedEventArgs e)
         {
+            // 处理PROJECTDIR标签
+            if (Constants.projectDirRegex.IsMatch(vsScript)) {
+                string[] dirTag = Constants.projectDirRegex.Split(vsScript);
+                string projectDir = new DirectoryInfo(wizardInfo.ProjectFile).Parent.FullName;
+                vsScript = dirTag[0] + dirTag[1] + "r\"" + projectDir + "\"" + dirTag[3];
+            }
+
             string[] inputTemplate = Constants.inputRegex.Split(vsScript);
 
             // 处理MEMORY标签

--- a/OKEGui/OKEGui/Utils/Constants.cs
+++ b/OKEGui/OKEGui/Utils/Constants.cs
@@ -64,6 +64,7 @@ namespace OKEGui.Utils
 
         //Input and Debug, Memory regex
         public static readonly Regex inputRegex = new Regex("# *OKE:INPUTFILE([\\s]+\\w+[ ]*=[ ]*)([r]*[\"'].*[\"'])", RegexOptions.Multiline | RegexOptions.IgnoreCase);
+        public static readonly Regex projectDirRegex = new Regex("# *OKE:PROJECTDIR([\\s]+\\w+[ ]*=[ ]*)([r]*[\"'].*[\"'])", RegexOptions.Multiline | RegexOptions.IgnoreCase);
         public static readonly Regex memoryRegex = new Regex("# *OKE:MEMORY([\\s]+core.max_cache_size+[ ]*=[ ]*)(\\d+)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
         public static readonly Regex debugRegex = new Regex("# *OKE:DEBUG([\\s]+\\w+[ ]*=[ ]*)(\\w+)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
 

--- a/dist/windows/examples/demo.vpy
+++ b/dist/windows/examples/demo.vpy
@@ -1,11 +1,18 @@
 import vapoursynth as vs
 import sys
+import os.path
 import math
 from vapoursynth import core
 import havsfunc as haf
 import mvsfunc as mvf
 
 core.num_threads = 8
+
+#OKE:PROJECTDIR
+projDir = '.'
+sys.path.insert(1, sdir) # some packages rely on having '' as sys.path[0]
+#import custom  # import python modules under the project directory
+#core.std.LoadPlugin(os.path.join(projDir, 'libcustom.dll')) # or load custom plugins
 
 #OKE:MEMORY
 core.max_cache_size = 8000


### PR DESCRIPTION
e.g. you can place custom python modules, VS plugins, and data files along
with project json and use these in your vpy to access them:

```python
#OKE:PROJECTDIR
pdir = '.'
sys.path.insert(1, pdir) # some packages rely on having '' as sys.path[0]
core.std.LoadPlugin(os.path.join(pdir, 'libcustom.dll'))
```

Note: in each vpy file, `#OKE:PROJECTDIR` can only be used once.