### PR TITLE
If noNuma is set, don't set numa node or thread affinity

### DIFF
--- a/OKEGui/OKEGui/Gui/ConfigPanel.xaml
+++ b/OKEGui/OKEGui/Gui/ConfigPanel.xaml
@@ -57,7 +57,7 @@
                 <ComboBoxItem Content="TRACE"/>
             </ComboBox>
             <TextBlock Margin="10,9" Height="30" Grid.Row="1" Grid.Column="0" Text="跳过Numa检测（AMD Ryzen 1000系列请勾选）"/>
-            <CheckBox HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Row="1" Grid.Column="1" IsChecked="{Binding Config.noNuma}"/>
+            <CheckBox HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Row="1" Grid.Column="1" IsChecked="{Binding Config.singleNuma}"/>
             <TextBlock Margin="10,9" Height="30" Grid.Row="2" Grid.Column="0" Text="开启AVX512烤鸡模式"/>
             <CheckBox HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Row="2" Grid.Column="1" IsChecked="{Binding Config.avx512}"/>
         </Grid>

--- a/OKEGui/OKEGui/JobProcessor/Video/X264Encoder.cs
+++ b/OKEGui/OKEGui/JobProcessor/Video/X264Encoder.cs
@@ -98,8 +98,11 @@ namespace OKEGui
         {
             StringBuilder sb = new StringBuilder();
 
-            sb.Append("/c \"start \"foo\" /b /wait /affinity 0xFFFFFFF /node ");
-            sb.Append(numaNode.ToString());
+            sb.Append("/c \"start \"foo\" /b /wait ");
+            if (!Initializer.Config.noNuma) {
+                sb.Append("/affinity 0xFFFFFFFFFFFFFFFF /node ");
+                sb.Append(numaNode.ToString());
+            }
             // 构建vspipe参数
             sb.Append(" \"" + VspipePath + "\"");
             sb.Append(" --y4m");

--- a/OKEGui/OKEGui/JobProcessor/Video/X264Encoder.cs
+++ b/OKEGui/OKEGui/JobProcessor/Video/X264Encoder.cs
@@ -99,7 +99,8 @@ namespace OKEGui
             StringBuilder sb = new StringBuilder();
 
             sb.Append("/c \"start \"foo\" /b /wait ");
-            if (!Initializer.Config.noNuma) {
+            if (!Initializer.Config.singleNuma)
+            {
                 sb.Append("/affinity 0xFFFFFFFFFFFFFFFF /node ");
                 sb.Append(numaNode.ToString());
             }

--- a/OKEGui/OKEGui/JobProcessor/Video/x265Encoder.cs
+++ b/OKEGui/OKEGui/JobProcessor/Video/x265Encoder.cs
@@ -106,9 +106,11 @@ namespace OKEGui
         private string BuildCommandline(string extractParam, int numaNode, List<string> vspipeArgs)
         {
             StringBuilder sb = new StringBuilder();
-
-            sb.Append("/c \"start \"foo\" /b /wait /affinity 0xFFFFFFF /node ");
-            sb.Append(numaNode.ToString());
+            sb.Append("/c \"start \"foo\" /b /wait ");
+            if (!Initializer.Config.noNuma) {
+                sb.Append("/affinity 0xFFFFFFFFFFFFFFFF /node ");
+                sb.Append(numaNode.ToString());
+            }
             // 构建vspipe参数
             sb.Append(" \"" + vspipePath + "\"");
             sb.Append(" --y4m");

--- a/OKEGui/OKEGui/JobProcessor/Video/x265Encoder.cs
+++ b/OKEGui/OKEGui/JobProcessor/Video/x265Encoder.cs
@@ -107,7 +107,8 @@ namespace OKEGui
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("/c \"start \"foo\" /b /wait ");
-            if (!Initializer.Config.noNuma) {
+            if (!Initializer.Config.singleNuma)
+            {
                 sb.Append("/affinity 0xFFFFFFFFFFFFFFFF /node ");
                 sb.Append(numaNode.ToString());
             }

--- a/OKEGui/OKEGui/Utils/Initializer.cs
+++ b/OKEGui/OKEGui/Utils/Initializer.cs
@@ -50,13 +50,13 @@ namespace OKEGui.Utils
             }
         }
 
-        private bool _noNuma = false;
-        public bool noNuma
+        private bool _singleNuma = false;
+        public bool singleNuma
         {
-            get => _noNuma;
+            get => _singleNuma;
             set
             {
-                _noNuma = value;
+                _singleNuma = value;
                 NotifyPropertyChanged();
             }
         }

--- a/OKEGui/OKEGui/Worker/NumaNode.cs
+++ b/OKEGui/OKEGui/Worker/NumaNode.cs
@@ -17,7 +17,7 @@ namespace OKEGui.Worker
 
         static NumaNode()
         {
-            if (Initializer.Config.noNuma)
+            if (Initializer.Config.singleNuma)
             {
                 CurrentNuma = 0;
                 NumaCount = 1;


### PR DESCRIPTION
When "skip numa detection" is enabled, we shouldn't start all jobs
on node 0.

while we're at it, also set default thread affinity to 64 processors
on a node (instead of only 28). Otherwise if you have 64 processors
per numa node and you start two jobs on each node, the two jobs will
compete for 28 of the 64 processors.