### PR TITLE
Separate intermediate & output files from BD source

### DIFF
--- a/OKEGui/OKEGui/Gui/ConfigPanel.xaml
+++ b/OKEGui/OKEGui/Gui/ConfigPanel.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:OKEGui"
         DataContext="{Binding RelativeSource={RelativeSource Self}}"
         mc:Ignorable="d"
-        Title="设置" Height="300" Width="500">
+        Title="设置" Height="370" Width="500">
     <Window.Resources>
         <Style TargetType="DataGridCell">
             <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -16,7 +16,7 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="70"/>
-            <RowDefinition Height="105"/>
+            <RowDefinition Height="187"/>
             <RowDefinition/>
         </Grid.RowDefinitions>
         <Grid Grid.Row="0" Height="70" VerticalAlignment="Top">
@@ -60,6 +60,8 @@
             <CheckBox HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Row="1" Grid.Column="1" IsChecked="{Binding Config.noNuma}"/>
             <TextBlock Margin="10,9" Height="30" Grid.Row="2" Grid.Column="0" Text="开启AVX512烤鸡模式"/>
             <CheckBox HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Row="2" Grid.Column="1" IsChecked="{Binding Config.avx512}"/>
+            <TextBlock Margin="10,44,10,-39" Height="30" Grid.Row="2" Grid.Column="0" Text="删除工作/输出目录路径中的以下目录层次（使用 / 分割）"/>
+            <TextBox Grid.Row="2" Text="{Binding Config.stripCommonPathCompnents}" Margin="10,74,13,-80" Grid.ColumnSpan="2"/>
         </Grid>
         <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>

--- a/OKEGui/OKEGui/Gui/MainWindow.xaml.cs
+++ b/OKEGui/OKEGui/Gui/MainWindow.xaml.cs
@@ -370,7 +370,7 @@ namespace OKEGui
             }
             else
             {
-                string path = Path.GetDirectoryName(item.InputFile);
+                string path = Path.GetDirectoryName(item.Taskfile.OutputPathPrefix);
                 string arg = path;
 
                 if (item.CurrentStatus == "完成")

--- a/OKEGui/OKEGui/JobProcessor/Demuxer/EACDemuxer.cs
+++ b/OKEGui/OKEGui/JobProcessor/Demuxer/EACDemuxer.cs
@@ -57,6 +57,7 @@ namespace OKEGui
         private List<Info> JobSub;
         private int length;
         private bool extractVideo;
+        private string WorkingPathPrefix;
 
         private static List<EacOutputTrackType> s_eacOutputs = new List<EacOutputTrackType> {
             new EacOutputTrackType(TrackCodec.RAW_PCM,    "RAW/PCM",            "flac",    true,  TrackType.Audio),
@@ -92,6 +93,7 @@ namespace OKEGui
                 JobSub.AddRange(jobProfile.SubtitleTracks);
             }
             extractVideo = jobProfile.ExtractVideo;
+            WorkingPathPrefix = jobProfile.WorkingPathPrefix;
         }
 
         private void StartEac(string arguments, bool asyncRead)
@@ -259,6 +261,7 @@ namespace OKEGui
                     Length = length,
                     RawOutput = line,
                     SourceFile = sourceFile,
+                    WorkingPathPrefix = WorkingPathPrefix,
                     Type = EacOutputToTrackType(match.Groups[2].Value),
                     DupOrEmpty = false
                 };

--- a/OKEGui/OKEGui/JobProcessor/Demuxer/TrackInfo.cs
+++ b/OKEGui/OKEGui/JobProcessor/Demuxer/TrackInfo.cs
@@ -33,6 +33,7 @@ namespace OKEGui
             public string Information;
             public string RawOutput;
             public string SourceFile;
+            public string WorkingPathPrefix;
             public TrackType Type;
             public bool DupOrEmpty;
             public int Length;
@@ -44,7 +45,7 @@ namespace OKEGui
             {
                 get
                 {
-                    var directory = Path.GetDirectoryName(SourceFile);
+                    var directory = Path.GetDirectoryName(WorkingPathPrefix);
                     var baseName = Path.GetFileNameWithoutExtension(SourceFile);
 
                     if (Type == TrackType.Video)

--- a/OKEGui/OKEGui/Task/TaskProfile.cs
+++ b/OKEGui/OKEGui/Task/TaskProfile.cs
@@ -32,6 +32,9 @@ namespace OKEGui.Model
         public string VideoFormat;
         public string AudioFormat;
 
+        public string WorkingPathPrefix;
+        public string OutputPathPrefix;
+
         public Object Clone()
         {
             TaskProfile clone = MemberwiseClone() as TaskProfile;

--- a/OKEGui/OKEGui/Utils/Initializer.cs
+++ b/OKEGui/OKEGui/Utils/Initializer.cs
@@ -104,6 +104,17 @@ namespace OKEGui.Utils
                 NotifyPropertyChanged();
             }
         }
+
+        private string _stripCommonPathCompnents = "BDBOX/BDROM/BD/BDMV/STREAM/BD_VIDEO";
+        public string stripCommonPathCompnents
+        {
+            get => _stripCommonPathCompnents;
+            set
+            {
+                _stripCommonPathCompnents = value;
+                NotifyPropertyChanged();
+            }
+        }
     }
 
     static class Initializer

--- a/OKEGui/OKEGui/Worker/ExecuteTaskService.cs
+++ b/OKEGui/OKEGui/Worker/ExecuteTaskService.cs
@@ -153,7 +153,7 @@ namespace OKEGui.Worker
 
                     if (profile.VideoFormat == "HEVC")
                     {
-                        videoJob.Output = new FileInfo(task.InputFile).FullName + ".hevc";
+                        videoJob.Output = task.Taskfile.WorkingPathPrefix + ".hevc";
                         if (!profile.EncoderParam.ToLower().Contains("--pools"))
                         {
                             videoJob.EncodeParam += " --pools " + NumaNode.X265PoolsParam(videoJob.NumaNode);
@@ -161,7 +161,7 @@ namespace OKEGui.Worker
                     }
                     else
                     {
-                        videoJob.Output = new FileInfo(task.InputFile).FullName;
+                        videoJob.Output = task.Taskfile.WorkingPathPrefix;
                         videoJob.Output += profile.ContainerFormat == "MKV" ? "_.mkv" : ".h264";
                         if (!profile.EncoderParam.ToLower().Contains("--threads") && NumaNode.UsableCoreCount > 10)
                         {
@@ -288,12 +288,12 @@ namespace OKEGui.Worker
                                         task.ChapterStatus = ChapterStatus.Added;
                                     }
 
-                                    FileInfo outputChapterFile =
+                                    FileInfo inputChapterFile =
                                         new FileInfo(Path.ChangeExtension(task.InputFile, ".txt"));
-                                    if (outputChapterFile.Exists && !File.Exists(outputChapterFile.FullName + ".bak"))
-                                    {
-                                        File.Move(outputChapterFile.FullName, outputChapterFile.FullName + ".bak");
-                                    }
+                                    FileInfo outputChapterFile =
+                                        new FileInfo(Path.ChangeExtension(task.Taskfile.WorkingPathPrefix, ".txt"));
+                                    if (inputChapterFile.Exists && !File.Exists(outputChapterFile.FullName))
+                                        File.Copy(inputChapterFile.FullName, outputChapterFile.FullName);
 
                                     chapterInfo.Save(ChapterTypeEnum.OGM, outputChapterFile.FullName);
                                     outputChapterFile.Refresh();
@@ -301,7 +301,7 @@ namespace OKEGui.Worker
                                     task.MediaOutFile.AddTrack(new ChapterTrack(chapterFile));
 
                                     // 用章节文件生成qpfile
-                                    string qpFileName = Path.ChangeExtension(task.InputFile, ".qpf");
+                                    string qpFileName = Path.ChangeExtension(task.Taskfile.WorkingPathPrefix, ".qpf");
                                     string qpFile = vJob.Vfr
                                         ? ChapterService.GenerateQpFile(chapterInfo, timecode)
                                         : ChapterService.GenerateQpFile(chapterInfo, vJob.Fps);
@@ -349,7 +349,7 @@ namespace OKEGui.Worker
                         AutoMuxer muxer = new AutoMuxer(mkvInfo.FullName, lsmash.FullName);
                         muxer.ProgressChanged += progress => task.ProgressValue = progress;
 
-                        OKEFile outFile = muxer.StartMuxing(Path.GetDirectoryName(task.InputFile) + "\\" + task.OutputFile, task.MediaOutFile);
+                        OKEFile outFile = muxer.StartMuxing(Path.GetDirectoryName(task.Taskfile.OutputPathPrefix) + "\\" + task.OutputFile, task.MediaOutFile);
                         task.OutputFile = outFile.GetFileName();
                         task.BitRate = CommandlineVideoEncoder.HumanReadableFilesize(outFile.GetFileSize(), 2);
                     }
@@ -360,7 +360,7 @@ namespace OKEGui.Worker
                         FileInfo lsmash = new FileInfo(".\\tools\\l-smash\\muxer.exe");
                         AutoMuxer muxer = new AutoMuxer(mkvInfo.FullName, lsmash.FullName);
                         muxer.ProgressChanged += progress => task.ProgressValue = progress;
-                        string mkaOutputFile = task.InputFile + ".mka";
+                        string mkaOutputFile = task.Taskfile.OutputPathPrefix + ".mka";
 
                         muxer.StartMuxing(mkaOutputFile, task.MkaOutFile);
                     }


### PR DESCRIPTION
This changes separates intermediate & output files into their own
directories.

To avoid file name conflicts, it will replicate the path to the BD's
STREAM directory as the working and output directory path, but it
allows user configurable stripping of common directory levels like
"BDMV", "BDROM", and "STREAM"..