### PR TITLE
Ignore unmatched properties when deserializing yaml

### DIFF
--- a/OKEGui/OKEGui/Task/AddTaskService.cs
+++ b/OKEGui/OKEGui/Task/AddTaskService.cs
@@ -31,7 +31,7 @@ namespace OKEGui
             TaskProfile json;
             try
             {
-                var deserializer = new Deserializer();
+                var deserializer = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
                 json = deserializer.Deserialize<TaskProfile>(profileStr);
             }
             catch (Exception e)


### PR DESCRIPTION
Existing JSON project files might contain commonly used properties
like "TrackId" that are actually not used in the model. This change
changes the YAML deserializer to also ignore those properties so
that existing JSON files can still be used.