### PR TITLE
Do not make assumptions on the relative order of various #OKE tags

### DIFF
--- a/OKEGui/OKEGui/Gui/WizardWindow.xaml.cs
+++ b/OKEGui/OKEGui/Gui/WizardWindow.xaml.cs
@@ -185,28 +185,29 @@ namespace OKEGui
                 vsScript = dirTag[0] + dirTag[1] + "r\"" + projectDir + "\"" + dirTag[3];
             }
 
-            string[] inputTemplate = Constants.inputRegex.Split(vsScript);
+            string updatedVsScript = vsScript;
 
             // 处理MEMORY标签
-            if(Constants.memoryRegex.IsMatch(vsScript))
+            if(Constants.memoryRegex.IsMatch(updatedVsScript))
             {
-                string[] memoryTag = Constants.memoryRegex.Split(inputTemplate[0]);
-                inputTemplate[0] = memoryTag[0] + memoryTag[1] + eachFreeMemory.ToString() + memoryTag[3];
+                string[] memoryTag = Constants.memoryRegex.Split(updatedVsScript);
+                updatedVsScript = memoryTag[0] + memoryTag[1] + eachFreeMemory.ToString() + memoryTag[3];
             }
 
             // 处理DEBUG标签
-            if (Constants.debugRegex.IsMatch(vsScript))
+            if (Constants.debugRegex.IsMatch(updatedVsScript))
             {
-                string[] debugTag = Constants.debugRegex.Split(inputTemplate[3]);
+                string[] debugTag = Constants.debugRegex.Split(updatedVsScript);
                 if (debugTag.Length < 4)
                 {
                     // error
                     System.Windows.MessageBox.Show("Debug标签语法错误！", "新建任务向导", MessageBoxButton.OK, MessageBoxImage.Error);
                     return;
                 }
-                inputTemplate[3] = debugTag[0] + debugTag[1] + "None" + debugTag[3];
+                updatedVsScript = debugTag[0] + debugTag[1] + "None" + debugTag[3];
             }
-            
+
+            string[] inputTemplate = Constants.inputRegex.Split(updatedVsScript);
 
             // 新建任务
             // 1、清理残留文件


### PR DESCRIPTION
For example, it's perfectly reasonable to have `#OKE:DEBUG` before `#OKE:INPUTFILE`.

The assumption seems to be: `#OKE:MEMORY` first, then `#OKE:INPUTFILE` and finally `#OKE:DEBUG`, but this is overly strict. This PR removes these assumptions. Now these tags can appear in arbitrary order.

```python
import vapoursynth as vs
core = vs.core

#OKE:DEBUG
Debug = True

#OKE:INPUTFILE
a = r'input.mkv'

#OKE:MEMORY
core.max_cache_size = 8000

src8 = core.lsmas.LWLibavSource(a)
# ....
```