### PR TITLE
Only update #OKE:MEMORY when specified free memory > 2GB

### DIFF
--- a/OKEGui/OKEGui/Gui/WizardWindow.xaml.cs
+++ b/OKEGui/OKEGui/Gui/WizardWindow.xaml.cs
@@ -77,8 +77,15 @@ namespace OKEGui
             DataContext = wizardInfo;
 
             workerManager = w;
-            
-            eachFreeMemory = (Initializer.Config.memoryLimit - workerManager.GetWorkerCount() * 2000) / workerManager.GetWorkerCount();
+
+            if (Initializer.Config.memoryLimit > 2000)
+            {
+                eachFreeMemory = (Initializer.Config.memoryLimit - workerManager.GetWorkerCount() * 2000) / workerManager.GetWorkerCount();
+            }
+            else
+            {
+                eachFreeMemory = 0;
+            }
         }
 
         // 读入json文件，检查项目设置，并生成预览信息
@@ -191,7 +198,7 @@ namespace OKEGui
             string updatedVsScript = vsScript;
 
             // 处理MEMORY标签
-            if(Constants.memoryRegex.IsMatch(updatedVsScript))
+            if (eachFreeMemory > 0 && Constants.memoryRegex.IsMatch(updatedVsScript))
             {
                 string[] memoryTag = Constants.memoryRegex.Split(updatedVsScript);
                 updatedVsScript = memoryTag[0] + memoryTag[1] + eachFreeMemory.ToString() + memoryTag[3];


### PR DESCRIPTION
so that it's possible to specify free memory 1MB if you don't use this feature.