### PR TITLE
Recognize eac3 and opus audio tracks

### DIFF
--- a/OKEGui/OKEGui/JobProcessor/Demuxer/EACDemuxer.cs
+++ b/OKEGui/OKEGui/JobProcessor/Demuxer/EACDemuxer.cs
@@ -68,6 +68,8 @@ namespace OKEGui
             new EacOutputTrackType(TrackCodec.FLAC,       "FLAC",               "flac",    true,  TrackType.Audio),
             new EacOutputTrackType(TrackCodec.AAC,        "AAC",                "aac",     true,  TrackType.Audio),
             new EacOutputTrackType(TrackCodec.DTS,        "DTS",                "dts",     true,  TrackType.Audio),
+            new EacOutputTrackType(TrackCodec.EAC3,       "EAC3",               "eac3",    true,  TrackType.Audio),
+            new EacOutputTrackType(TrackCodec.OPUS,       "OPUS",               "opus",    true,  TrackType.Audio),
             new EacOutputTrackType(TrackCodec.MPEG2,      "MPEG2",              "m2v",     false, TrackType.Video),
             new EacOutputTrackType(TrackCodec.H264_AVC,   "h264/AVC",           "264",     false, TrackType.Video),
             new EacOutputTrackType(TrackCodec.H265_HEVC,  "h265/HEVC",          "265",     false, TrackType.Video),

--- a/OKEGui/OKEGui/JobProcessor/Demuxer/TrackInfo.cs
+++ b/OKEGui/OKEGui/JobProcessor/Demuxer/TrackInfo.cs
@@ -20,6 +20,8 @@ namespace OKEGui
             TRUEHD_AC3,
             AC3,
             DTS,
+            EAC3,
+            OPUS,
             PGS,
             Chapter,
             VobSub,


### PR DESCRIPTION
However, no (lossy) reencoding support.

OK to merge before portable 23H1.