### PR TITLE
show remaining time up to 7 days

### DIFF
--- a/OKEGui/OKEGui/Task/TaskStatus.cs
+++ b/OKEGui/OKEGui/Task/TaskStatus.cs
@@ -192,9 +192,9 @@ namespace OKEGui
             {
                 timeRemain = value;
                 TimeRemainStr = value.ToString(@"hh\:mm\:ss");
-                if (value.TotalHours > 24.0)
+                if (value.TotalHours > 24.0*7)
                 {
-                    TimeRemainStr = "大于一天";
+                    TimeRemainStr = "大于一周";
                 }
             }
         }


### PR DESCRIPTION
~~unfortunately, some of our scripts are just this slow.~~ when encoding long live contents, 24h is likely not enough.