### PR TITLE
Re-target the project to .NET Framework 4.7.2

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -36,7 +36,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1.1
 
     - name: Restore packages
-      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration /p:RestorePackagesConfig=True
+      run: msbuild $env:Solution_Name /t:Restore /p:Platform=$env:TargetPlatform /p:Configuration=$env:Configuration /p:RestorePackagesConfig=True
 
     # Build the Application project
     - name: Build the Application Project

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -19,7 +19,7 @@ jobs:
         configuration: [Release]
         targetplatform: [x64]
 
-    runs-on: windows-2019    # For a list of available runner types, refer to
+    runs-on: windows-2022    # For a list of available runner types, refer to
                              # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 
     env:
@@ -31,32 +31,16 @@ jobs:
       with:
         submodules: true
 
-    # Install the .NET workload
-    - name: Install .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 5.0.x
-
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.1
 
-    - uses: nuget/setup-nuget@v1
-      with:
-        nuget-version: '5.x'
-
-    - name: Restore Nuget packages
-      run: nuget restore $env:Solution_Name
-
-    # Restore the application to populate the obj folder with RuntimeIdentifiers
-    - name: Restore the application
-      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
-      env:
-        Configuration: ${{ matrix.configuration }}
+    - name: Restore packages
+      run: msbuild $env:Solution_Name /t:Restore /p:RestorePackagesConfig=True
 
     # Build the Application project
     - name: Build the Application Project
-      run: msbuild $env:Solution_Name /p:Platform=$env:TargetPlatform /p:Configuration=$env:Configuration /p:UapAppxPackageBuildMode=$env:BuildMode /p:AppxBundle=$env:AppxBundle
+      run: msbuild $env:Solution_Name /t:OKEGui /p:Platform=$env:TargetPlatform /p:Configuration=$env:Configuration /p:UapAppxPackageBuildMode=$env:BuildMode /p:AppxBundle=$env:AppxBundle
       env:
         AppxBundle: Never
         BuildMode: SideloadOnly

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -37,6 +37,9 @@ jobs:
 
     - name: Restore packages
       run: msbuild $env:Solution_Name /t:Restore /p:Platform=$env:TargetPlatform /p:Configuration=$env:Configuration /p:RestorePackagesConfig=True
+      env:
+        Configuration: ${{ matrix.configuration }}
+        TargetPlatform: ${{ matrix.targetplatform }}
 
     # Build the Application project
     - name: Build the Application Project

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -36,7 +36,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1.1
 
     - name: Restore packages
-      run: msbuild $env:Solution_Name /t:Restore /p:RestorePackagesConfig=True
+      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration /p:RestorePackagesConfig=True
 
     # Build the Application project
     - name: Build the Application Project

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v3
@@ -16,9 +16,6 @@ jobs:
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.1
-
-    - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1
 
     - name: Setup Go
       uses: actions/setup-go@v2
@@ -36,12 +33,12 @@ jobs:
         go build -ldflags "-X main.version=$(git describe --tags)"
         cd ..
 
-    - name: Restore Packages
-      run: nuget restore OKEGui/OKEGui.sln
+    - name: Restore packages
+      run: msbuild.exe OKEGui/OKEGui.sln /t:Restore /p:RestorePackagesConfig=True
 
     - name: Build Solution
       run: |
-        msbuild.exe OKEGui/OKEGui.sln /nologo /p:DeleteExistingFiles=True /p:platform="Any CPU" /p:configuration="Release"
+        msbuild.exe OKEGui/OKEGui.sln /nologo /t:OKEGui /p:DeleteExistingFiles=True /p:platform="Any CPU" /p:configuration="Release"
 
     - name: Integrate tools pack from previous release
       shell: bash

--- a/OKEGui/OKEGui/App.config
+++ b/OKEGui/OKEGui/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
   </startup>
 </configuration>

--- a/OKEGui/OKEGui/OKEGui.csproj
+++ b/OKEGui/OKEGui/OKEGui.csproj
@@ -205,18 +205,6 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.5">
-      <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.5 %28x86 和 x64%29</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <ItemGroup>
     <Page Include="Gui\ConfigPanel.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/OKEGui/OKEGui/OKEGui.csproj
+++ b/OKEGui/OKEGui/OKEGui.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OKEGui</RootNamespace>
     <AssemblyName>OKEGui</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -45,7 +45,6 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <CodeAnalysisRuleSet>SecurityRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>x64</PlatformTarget>
@@ -56,7 +55,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Gui\App.ico</ApplicationIcon>
@@ -80,9 +78,6 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
-    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
@@ -269,19 +264,11 @@
     </ItemGroup>
   </Target>
   <Target Name="ILRepack" AfterTargets="Build" Condition="'$(Configuration)' == 'Debug' or '$(Configuration)' == 'Release'">
-     <ItemGroup>
-         <InputAssemblies Include="$(TargetPath)"/>
-         <InputAssemblies Include="$(OutputPath)\NLog.dll" />
-     </ItemGroup>
-
-     <ILRepack
-         AllowDuplicateResources="false"
-         DebugInfo="true"
-         Internalize="false"
-         InputAssemblies="@(InputAssemblies)"
-         OutputFile="$(TargetPath)"
-         Parallel="true"
-         TargetKind="SameAsPrimaryAssembly" />
+    <ItemGroup>
+      <InputAssemblies Include="$(TargetPath)" />
+      <InputAssemblies Include="$(OutputPath)\NLog.dll" />
+    </ItemGroup>
+    <ILRepack AllowDuplicateResources="false" DebugInfo="true" Internalize="false" InputAssemblies="@(InputAssemblies)" OutputFile="$(TargetPath)" Parallel="true" TargetKind="SameAsPrimaryAssembly" />
   </Target>
   <Target AfterTargets="ILRepack" Name="CleanReferenceCopyLocalPaths">
     <Delete Files="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename)%(Extension)')" />

--- a/OKEGui/OKEGui/Properties/Resources.Designer.cs
+++ b/OKEGui/OKEGui/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace OKEGui.Properties {
     // 类通过类似于 ResGen 或 Visual Studio 的工具自动生成的。
     // 若要添加或移除成员，请编辑 .ResX 文件，然后重新运行 ResGen
     // (以 /str 作为命令选项)，或重新生成 VS 项目。
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/OKEGui/OKEGui/Properties/Settings.Designer.cs
+++ b/OKEGui/OKEGui/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace OKEGui.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.5.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/OKEGui/OKEGui/packages.config
+++ b/OKEGui/OKEGui/packages.config
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Extended.Wpf.Toolkit" version="3.5.0" targetFramework="net45" />
-  <package id="ILRepack.Lib.MSBuild.Task" version="2.0.18.2" targetFramework="net45" />
-  <package id="MediaInfo.Native" version="21.3.0" targetFramework="net45" />
-  <package id="MediaInfo.Wrapper" version="21.3.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NLog" version="4.6.7" targetFramework="net45" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net45" />
-  <package id="YamlDotNet" version="11.1.1" targetFramework="net45" />
+  <package id="Extended.Wpf.Toolkit" version="3.5.0" targetFramework="net472" />
+  <package id="ILRepack.Lib.MSBuild.Task" version="2.0.18.2" targetFramework="net472" />
+  <package id="MediaInfo.Native" version="21.3.0" targetFramework="net472" />
+  <package id="MediaInfo.Wrapper" version="21.3.0" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net472" />
+  <package id="NLog" version="4.6.7" targetFramework="net472" />
+  <package id="YamlDotNet" version="11.1.1" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Change the target to .NET Framework 4.7.2. Drop support for older operating systems. A minimum version of Windows 10 v1803 or Windows Server 2019 is required for this build.